### PR TITLE
Add bark.Fields alias and remove meme comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # timberyard
 Global logging helper for Fresh8 services exposing uber-common/bark.Logger
+
+## Requirements
+- Go 1.9+

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -7,8 +7,8 @@ import (
 	"github.com/uber-common/bark"
 )
 
-// Fields is an alias for logrus.Fields to keep dem imports tidy like
-type Fields map[string]interface{}
+// Fields is an alias for bark.Fields
+type Fields = bark.Fields
 
 // Log is the importable logger
 var logger bark.Logger


### PR DESCRIPTION
This allows us to use `logging.Fields` instead of having to import `bark` just to use its Fields type.